### PR TITLE
Removed EasyArgs dependency.

### DIFF
--- a/StegoSharp/StegoSharp/StegoSharp.csproj
+++ b/StegoSharp/StegoSharp/StegoSharp.csproj
@@ -36,10 +36,6 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EasyArgs, Version=1.0.5939.25840, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\EasyArgs.1.0.5939.25840\lib\net461\EasyArgs.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
Heya,

StegoSharp required EasyArgs, but it is not used anywhere in the code and not needed. I had problems installing the StegoSharp NuGet Package because EasyArgs has no assembly for .Net 4.5 or 4.5.2, so I removed it. 

Greetings