### PR TITLE
Add IDisposable support to StegoImage

### DIFF
--- a/StegoSharp/StegoSharp.sln
+++ b/StegoSharp/StegoSharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StegoSharp", "StegoSharp\StegoSharp.csproj", "{2442E986-696A-406B-A349-AAA3C652FE1A}"
 EndProject
@@ -15,19 +15,32 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2442E986-696A-406B-A349-AAA3C652FE1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2442E986-696A-406B-A349-AAA3C652FE1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2442E986-696A-406B-A349-AAA3C652FE1A}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2442E986-696A-406B-A349-AAA3C652FE1A}.Debug|Any CPU.Build.0 = Debug|x86
+		{2442E986-696A-406B-A349-AAA3C652FE1A}.Debug|x86.ActiveCfg = Debug|x86
+		{2442E986-696A-406B-A349-AAA3C652FE1A}.Debug|x86.Build.0 = Debug|x86
 		{2442E986-696A-406B-A349-AAA3C652FE1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2442E986-696A-406B-A349-AAA3C652FE1A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B136D070-A746-483C-8483-29888BF149B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B136D070-A746-483C-8483-29888BF149B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2442E986-696A-406B-A349-AAA3C652FE1A}.Release|x86.ActiveCfg = Release|x86
+		{2442E986-696A-406B-A349-AAA3C652FE1A}.Release|x86.Build.0 = Release|x86
+		{B136D070-A746-483C-8483-29888BF149B6}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{B136D070-A746-483C-8483-29888BF149B6}.Debug|Any CPU.Build.0 = Debug|x86
+		{B136D070-A746-483C-8483-29888BF149B6}.Debug|x86.ActiveCfg = Debug|x86
+		{B136D070-A746-483C-8483-29888BF149B6}.Debug|x86.Build.0 = Debug|x86
 		{B136D070-A746-483C-8483-29888BF149B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B136D070-A746-483C-8483-29888BF149B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B136D070-A746-483C-8483-29888BF149B6}.Release|x86.ActiveCfg = Release|x86
+		{B136D070-A746-483C-8483-29888BF149B6}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {69621C09-F687-4558-891B-46F9325979CD}
 	EndGlobalSection
 EndGlobal

--- a/StegoSharp/StegoSharp/StegoImage.cs
+++ b/StegoSharp/StegoSharp/StegoImage.cs
@@ -10,7 +10,7 @@ using System.Text;
 namespace StegoSharp
 {
 
-    public class StegoImage
+    public class StegoImage : IDisposable
     {
 
         public const int BitsInAByte = 8;
@@ -288,6 +288,11 @@ namespace StegoSharp
                     yield return Tuple.Create(pixel, otherPixel);
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            _image.Dispose();
         }
     }
 }

--- a/StegoSharp/StegoSharp/StegoSharp.csproj
+++ b/StegoSharp/StegoSharp/StegoSharp.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StegoSharp</RootNamespace>
     <AssemblyName>StegoSharp</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -34,6 +34,24 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/StegoSharp/UnitTests/Tests/StegoImageTests.cs
+++ b/StegoSharp/UnitTests/Tests/StegoImageTests.cs
@@ -12,24 +12,25 @@ namespace UnitTests.Tests
         public void EmbedBytes_should_embed_a_byte_array_into_the_image()
         {
             var path = @"images/iguana.png";
-
-            var image = new StegoImage(path);
-
-            var message = "We exist without skin color," +
-                "without nationality, without religious bias... and you call us criminals." +
-                "You build atomic bombs, you wage wars, you murder, cheat, and lie to us" +
-                "and try to make us believe it's for our own good, yet we're the criminals.";
-
             var resultPath = @"iguana-embedded.png";
+            var message = "We exist without skin color," +
+                          "without nationality, without religious bias... and you call us criminals." +
+                          "You build atomic bombs, you wage wars, you murder, cheat, and lie to us" +
+                          "and try to make us believe it's for our own good, yet we're the criminals.";
 
-            image.EmbedPayload(message)
-                 .Save(resultPath);
-            
-            var imageWithMessage = new StegoImage(resultPath);
-            var embeddedString = Encoding.Default.GetString(imageWithMessage.ExtractBytes().ToArray());
-            var embedded = embeddedString.Substring(0, message.Length);
+            using (var image = new StegoImage(path))
+            {
+                image.EmbedPayload(message)
+                    .Save(resultPath);
+            }
 
-            Assert.Equal(message, embedded);
+            using (var imageWithMessage = new StegoImage(resultPath))
+            {
+                var embeddedString = Encoding.Default.GetString(imageWithMessage.ExtractBytes().ToArray());
+                var embedded = embeddedString.Substring(0, message.Length);
+
+                Assert.Equal(message, embedded);
+            }
         }
 
         [Fact]
@@ -38,58 +39,72 @@ namespace UnitTests.Tests
             var message = "The probability of success is difficult to estimate; but if we never search the chance of success is zero.";
 
             var slothPath = @"images/sloth.png";
-            var slothImage = new StegoImage(slothPath);
-            slothImage.Strategy.PixelSelection = p => p.Index % 2 == 0;
-            slothImage.EmbedPayload(Encoding.Default.GetBytes(message));
-
             var slothEmbeddedPath = @"sloth-embedded.png";
-            slothImage.Save(slothEmbeddedPath);
+            using (var slothImage = new StegoImage(slothPath))
+            {
+                slothImage.Strategy.PixelSelection = p => p.Index % 2 == 0;
+                slothImage.EmbedPayload(Encoding.Default.GetBytes(message));
+
+                slothImage.Save(slothEmbeddedPath);
+            }
+
             var slothBytes = File.ReadAllBytes(slothEmbeddedPath);
 
             // embed the sloth into the astronaut
             var astronautPath = @"images/astronaut.png";
-            var astronautImage = new StegoImage(astronautPath);
-            astronautImage.EmbedPayload(slothBytes);
-
-            // save the astronaut
             var embeddedAstronautPath = @"astronaut-embedded.png";
-            astronautImage.Save(embeddedAstronautPath);
+            using (var astronautImage = new StegoImage(astronautPath))
+            {
+                astronautImage.EmbedPayload(slothBytes);
+
+                // save the astronaut
+                astronautImage.Save(embeddedAstronautPath);
+            }
+
             var astronautBytes = File.ReadAllBytes(embeddedAstronautPath);
 
             // embed the astronaut into space
             var spacePath = @"images/space.png";
-            var spaceImage = new StegoImage(spacePath);
-            spaceImage.EmbedPayload(astronautBytes);
-
-            // save space
             var spaceEmbeddedPath = @"space-embedded.png";
-            spaceImage.Save(spaceEmbeddedPath);
+            using (var spaceImage = new StegoImage(spacePath))
+            {
+                spaceImage.EmbedPayload(astronautBytes);
+
+                // save space
+                spaceImage.Save(spaceEmbeddedPath);
+            }
 
             // extract the astronaut
-            var spaceEmbeddedImage = new StegoImage(spaceEmbeddedPath);
-            var embeddedAstronautBytes = spaceEmbeddedImage.ExtractBytes()
-                .Take(astronautBytes.Length)
-                .ToArray();
+            using (var spaceEmbeddedImage = new StegoImage(spaceEmbeddedPath))
+            {
+                var embeddedAstronautBytes = spaceEmbeddedImage.ExtractBytes()
+                    .Take(astronautBytes.Length)
+                    .ToArray();
 
-            Assert.Equal(astronautBytes, embeddedAstronautBytes);
+                Assert.Equal(astronautBytes, embeddedAstronautBytes);
 
-            var astronautBytesPath = @"astronaut-embedded-bytes.png";
-            File.WriteAllBytes(astronautBytesPath, embeddedAstronautBytes);
+                var astronautBytesPath = @"astronaut-embedded-bytes.png";
+                File.WriteAllBytes(astronautBytesPath, embeddedAstronautBytes);
 
-            var astronautBytesImage = new StegoImage(astronautBytesPath);
-            var embeddedSlothBytes = astronautBytesImage.ExtractBytes().Take(slothBytes.Length).ToArray();
+                using (var astronautBytesImage = new StegoImage(astronautBytesPath))
+                {
+                    var embeddedSlothBytes = astronautBytesImage.ExtractBytes().Take(slothBytes.Length).ToArray();
 
-            Assert.Equal(slothBytes, embeddedSlothBytes);
+                    Assert.Equal(slothBytes, embeddedSlothBytes);
 
-            var slothBytesPath = @"sloth-embedded-bytes.png";
-            File.WriteAllBytes(slothBytesPath, embeddedSlothBytes);
+                    var slothBytesPath = @"sloth-embedded-bytes.png";
+                    File.WriteAllBytes(slothBytesPath, embeddedSlothBytes);
 
-            var slothBytesImage = new StegoImage(slothBytesPath);
-            slothBytesImage.Strategy.PixelSelection = p => p.Index % 2 == 0;
-            var embeddedMessage = Encoding.Default.GetString(slothBytesImage.ExtractBytes().ToArray())
-                .Substring(0, message.Length);
+                    using (var slothBytesImage = new StegoImage(slothBytesPath))
+                    {
+                        slothBytesImage.Strategy.PixelSelection = p => p.Index % 2 == 0;
+                        var embeddedMessage = Encoding.Default.GetString(slothBytesImage.ExtractBytes().ToArray())
+                            .Substring(0, message.Length);
 
-            Assert.Equal(message, embeddedMessage);
+                        Assert.Equal(message, embeddedMessage);
+                    }
+                }
+            }
         }
     }
 }

--- a/StegoSharp/UnitTests/UnitTests.csproj
+++ b/StegoSharp/UnitTests/UnitTests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UnitTests</RootNamespace>
     <AssemblyName>UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>dc641ca9</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -31,6 +31,24 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
GDI+ Image() adds an exclusive file lock until disposed - was manifesting in my usage of StegoImage in a very bad hard fail way.

Please feel free to ignore the updates the solution and project files - the import parts of this change are in the StegoImage and tests.